### PR TITLE
use POSIX sh with #!/bin/sh

### DIFF
--- a/tools/dev_pages.sh
+++ b/tools/dev_pages.sh
@@ -3,13 +3,13 @@
 # Generate SBO::Lib::*.3 pages. Pass --all to generate all
 # pages, or the names of one or more individual modules.
 
-if ! [[ -d "./man3" ]]; then
+if ! [ -d "./man3" ]; then
 	echo "you do not seem to be at the right place to run this."
 	echo "the man3/ directory should be under ."
 	exit 1
 fi
 
-if [[ -z $1 ]]; then
+if [ -z $1 ]; then
   echo "Usage: e.g., ./tools/dev_pages.sh Build Tree"
   echo "Usage:       ./tools/dev_pages.sh --all"
   exit 1
@@ -21,7 +21,7 @@ fi
 version=$(grep '^our $VERSION' SBO-Lib/lib/SBO/Lib.pm | grep -Eo '[0-9]+(\.[0-9RC@gita-f_]+){0,2}')
 datestring="$(ddate +"%{%A, %B %d%}, %Y YOLD%N - %H")"
 cd SBO-Lib/lib || exit
-if [[ $1 = '--all' ]]; then
+if [ $1 = '--all' ]; then
   for item in Build Download Help Info Pkgs Readme Repo Solibs Tree Util ; do
     pod2man -r "" -c "sbotools $version" -d "$datestring" SBO/Lib/$item.pm ../../man3/SBO::Lib::$item.3
   done
@@ -29,10 +29,10 @@ if [[ $1 = '--all' ]]; then
   exit
 fi
 
-while [[ -n $@ ]]; do
-  if [[ -f SBO/Lib/$1.pm ]]; then
+while [ -n "$(echo $@)" ]; do
+  if [ -f SBO/Lib/$1.pm ]; then
     pod2man -r "" -c "sbotools $version" -d "$datestring" SBO/Lib/$1.pm ../../man3/SBO::Lib::$1.3
-  elif [[ $1 -eq "Lib" && -f SBO/Lib.pm ]]; then
+  elif [ $1 = "Lib" -a -f SBO/Lib.pm ]; then
     pod2man -r "" -c "sbotools $version" -d "$datestring" SBO/Lib.pm ../../man3/SBO::Lib.3
   else
     echo "The file $1.pm does not exist. Skipping."

--- a/tools/update_man_pages.sh
+++ b/tools/update_man_pages.sh
@@ -5,22 +5,18 @@ usage_exit() {
 	exit 1
 }
 
-if [[ "$1" == "-h" ]]; then
+if [ "$1" = "-h" -o "$1" = "-?" ]; then
 	usage_exit
 fi
 
-if [[ "$1" == "-?" ]]; then
-	usage_exit
-fi
-
-if [[ "$1" == "-d" ]]; then
+if [ "$1" = "-d" ]; then
 	date=true
 	shift
 fi
 
 version=$(grep '^our $VERSION' SBO-Lib/lib/SBO/Lib.pm | grep -Eo '[0-9]+(\.[0-9RC@gita-f_]+){0,2}')
 
-if ! [[ -d "./man1" ]]; then
+if ! [ -d "./man1" ]; then
 	echo "you do not seem to be at the right place to run this."
 	echo "the man{1,5}/ directories should be under ."
 	exit 1
@@ -29,7 +25,7 @@ fi
 tmpfile=$(mktemp /tmp/XXXXXXXXX)
 
 sed_file() {
-	if [[ "$1" == "" || "$2" == "" ]]; then
+	if [ "$1" = "" -o "$2" = "" ]; then
 		echo "sed_file(): two arguments required."
 		exit 1
 	fi
@@ -38,12 +34,11 @@ sed_file() {
 	sed_cmd="$2"
 
 	cat $file | sed "$sed_cmd" > $tmpfile
-	if [[ "$?" == "0" ]]; then
-		mv $tmpfile $file
-	else
+	if [ "$?" != "0" ]; then
 		return 1
 	fi
 
+	mv $tmpfile $file
 	return 0
 }
 
@@ -57,7 +52,7 @@ for i in $(ls man5); do
 	sed_file man5/$i "s/\"sbotools $old_version\"/\"sbotools $version\"/g"
 done
 
-if [[ "$?" == "0" ]]; then
+if [ "$?" = "0" ]; then
 	echo "version updated."
 fi
 
@@ -79,23 +74,19 @@ update_date() {
 		sed_file $i "s/$old_date/$new_date/g"
 	done
 
-	if [[ "$?" == "0" ]]; then
-		echo "date updated."
-	else
+	if [ "$?" != "0" ]; then
 		return 1
 	fi
 
+	echo "date updated."
 	return 0
 }
 
-date_return=0
-if [[ "$date" == "true" ]]; then
+if [ "$date" = "true" ]; then
 	update_date
-	date_return=$?
-fi
-
-if [[ "$date_return" != "0" ]]; then
-	exit 1
+	if [ "$?" != "0" ]; then
+	    exit 1
+    fi
 fi
 
 # Regenerate the man3 pages, just in case.

--- a/tools/update_versions.sh
+++ b/tools/update_versions.sh
@@ -1,28 +1,11 @@
 #!/bin/sh
 
 usage_exit() {
-	echo "Usage: $(basename $0) (-g) version"
+	echo "Usage: $(basename $0) version"
 	exit 1
 }
 
-if [[ "$1" == "" ]]; then
-	usage_exit
-fi
-
-if [[ "$1" == "-?" ]]; then
-	usage_exit
-fi
-
-if [[ "$1" == "-h" ]]; then
-	usage_exit
-fi
-
-if [[ "$1" == "-g" ]]; then
-	git=true
-	shift
-fi
-
-if [[ "$1" == "" ]]; then
+if [ "$1" = "" -o "$1" = "-?" -o "$1" = "-h" ]; then
 	usage_exit
 fi
 
@@ -55,14 +38,14 @@ tmpfile=$(mktemp /tmp/XXXXXXXXXX)
 
 for i in $update_other; do
 	cat $i | sed "s/$old_version/$version/g" > $tmpfile
-	if [[ "$?" == "0" ]]; then
+	if [ "$?" = "0" ]; then
 		mv $tmpfile $i
 	fi
 done
 
 for i in $update_perl; do
   cat $i | sed "s/'$old_version'/'$version'/g" > $tmpfile
-  if [[ "$?" == "0" ]]; then
+  if [ "$?" = "0" ]; then
     mv $tmpfile $i
   fi
 done


### PR DESCRIPTION
This change causes shell scripts that use "#!/bin/sh" as their shebang to only contain syntax which is available in POSIX sh. Along the way I fixed an integer/string comparison bug that I happened to see in tools/dev_pages.sh (line 35), compressed some things that seemed to need it, and removed the unused "-g" bits from tools/update_versions.sh. All scripts appear to function correctly with these changes.